### PR TITLE
Added support for nologo and maxcpucount options in MSBuild

### DIFF
--- a/lib/albacore/msbuild.rb
+++ b/lib/albacore/msbuild.rb
@@ -6,7 +6,7 @@ class MSBuild
   include Albacore::RunCommand
   include Configuration::MSBuild
   
-  attr_accessor :solution, :verbosity, :loggermodule
+  attr_accessor :solution, :verbosity, :loggermodule, :max_cpu_count
   attr_array :targets
   attr_hash :properties
   
@@ -30,6 +30,7 @@ class MSBuild
     command_parameters << "\"#{solution}\""
     command_parameters << "\"/verbosity:#{@verbosity}\"" if @verbosity != nil
     command_parameters << "\"/logger:#{@loggermodule}\"" if @loggermodule != nil
+    command_parameters << "\"/maxcpucount:#{@max_cpu_count}\"" if @max_cpu_count != nil
     command_parameters << "\"/nologo\"" if @nologo
     command_parameters << build_properties if @properties != nil
     command_parameters << "\"/target:#{build_targets}\"" if @targets != nil

--- a/spec/msbuild_spec.rb
+++ b/spec/msbuild_spec.rb
@@ -230,4 +230,17 @@ describe MSBuild, "when specifying nologo" do
   end
 end
 
+describe MSBuild, "when specifying max cpu count" do
+  include_context "prepping msbuild"
+
+  before :all do
+    @msbuild.max_cpu_count = 2
+    @msbuild.solution = @testdata.solution_path
+    @msbuild.execute
+  end
+
+  it "should call msbuild with maxcpucount option set" do
+    @msbuild.system_command.should include("/maxcpucount:2")
+  end
+end
 


### PR DESCRIPTION
I wasn't sure if there was some kind of naming convention so:
- nologo is just a method that accepts no arguments and when called will tack a /nologo in the command line
- max_cpu_count is a property that behaves just like the others and tacks on a /maxcpucount=n to the command line
