### PR TITLE
Added support to override destination files on extraction for UnZip task

### DIFF
--- a/lib/albacore/unzip.rb
+++ b/lib/albacore/unzip.rb
@@ -6,7 +6,7 @@ include Zip
 class Unzip
   include Albacore::Task
   
-  attr_accessor :destination, :file, :force
+  attr_accessor :destination, :file
 
   def initialize
     super()
@@ -26,5 +26,9 @@ class Unzip
         zip_f.extract(f, out_path) unless File.exist?(out_path)
       end
     end
+  end
+  
+  def force
+    @force = true
   end
 end

--- a/spec/unzip_spec.rb
+++ b/spec/unzip_spec.rb
@@ -5,14 +5,21 @@ describe Unzip, "when providing configuration" do
   let :uz do
     Albacore.configure do |config|
       config.unzip.file = "configured"
-      config.unzip.force = true
     end
     uz = Unzip.new
   end
 
   it "should use the configured values" do
     uz.file.should == "configured"
-    uz.force.should be_true
+  end
+
+  it "should not 'force' by default" do
+    uz.instance_variable_get(:@force).should be_nil
+  end
+  
+  it "should enable 'force' by calling the force() method" do
+    uz.force
+    uz.instance_variable_get(:@force).should be_true
   end
 end
 
@@ -38,14 +45,13 @@ describe Unzip, "when executing the task" do
   it "should delete the destinationfile if forced" do
     File.should_receive(:delete).with('/tmp/foo.txt')
 
-    uz.force = true
+    uz.force
     uz.execute
   end
 
   it "should keep the destination file if not forced" do
     File.should_not_receive(:delete)
 
-    uz.force = false
     uz.execute
   end
 end


### PR DESCRIPTION
To improve the [UnZip task](https://github.com/mhoyer/albacore/wiki/UnZip-Task) I added another attribute `:force` to support overwriting destination files when unzipping a source .zip file.

My recommendation for the [UnZip wiki page](https://github.com/mhoyer/albacore/wiki/UnZip-Task):

The unzip task has a number of properties to find the files to zip and where to save the output. 
- **file** – this is the filename of the zip
- **destination** – Where you want the contents of the zip to be extracted to. In this example, it is the same directory as your build file.
- **force** – (optional, default=false) when set true it will delete each target file before unzipping from .zip file to destination.

``` ruby
unzip do |unzip|
  unzip.destination = File.dirname(__FILE__)
  unzip.file = "Archive.zip"
  unzip.force
end
```
