### PR TITLE
ensure file_name is set if flatten_zip is false when zipping additional ...

### DIFF
--- a/lib/albacore/zipdirectory.rb
+++ b/lib/albacore/zipdirectory.rb
@@ -88,8 +88,7 @@ class ZipDirectory
     return if @directories_to_zip.nil?
     @directories_to_zip.each do |d|
       Dir["#{d}/**/**"].reject{|f| reject_file(f)}.each do |file_path|
-        file_name = file_path
-        file_name = file_path.sub(d + '/','') if @flatten_zip
+        file_name = @flatten_zip ? file_path.sub(d + '/','') : file_path
         zipfile.add(file_name, file_path)
       end
     end
@@ -99,8 +98,7 @@ class ZipDirectory
     return if @additional_files.nil?
     @additional_files = Array.[](@additional_files).flatten
     @additional_files.reject{|f| reject_file(f)}.each do |file_path|
-      file_name = file_path
-      file_name = file_path.split('/').last if @flatten_zip
+      file_name = @flatten_zip ? file_path.split('/').last : file_path
       zipfile.add(file_name, file_path)
     end
   end

--- a/spec/zip_spec.rb
+++ b/spec/zip_spec.rb
@@ -158,3 +158,32 @@ describe ZipDirectory, 'when zipping a directory of files with additional files'
     end
   end
 end
+
+describe ZipDirectory, "with flatten_zip set to false" do
+    before :each do
+      zip = ZipDirectory.new
+      zip.directories_to_zip File.join('spec', 'support', 'yamlconfig')
+      zip.flatten_zip = false
+      zip.output_file = 'test.zip'
+      zip.output_path = ZipTestData.folder
+      zip.additional_files = [File.join('spec', 'support', 'test.yml'), File.join('spec', 'support', 'AssemblyInfo', 'assemblyinfo.yml')]
+      zip.execute
+
+      unzip = Unzip.new
+      unzip.file = File.join(ZipTestData.folder, 'test.zip')
+      unzip.destination = ZipTestData.output_folder
+      unzip.execute
+    end
+
+    after :each do
+      FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+    end
+
+    it "should add additional file" do
+      File.exist?(File.join(ZipTestData.folder, "test.zip")).should be_true
+      Dir.exist?(File.join(ZipTestData.output_folder, 'spec', 'support', 'yamlconfig')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'spec', 'support', 'yamlconfig', 'msbuild.yml')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'spec', 'support', 'test.yml')).should be_true
+    end
+end
+


### PR DESCRIPTION
With the zip task, if you set flatten_zip to false and you include additional files, it errors with:

```
add failed. Entry  already exists
```

This is because the file_name is only set to a value if @flatten_zip:

``` ruby
file_name = file_path.split('/').last if @flatten_zip
```

I have fixed this with a simple one line change. My usage is:

``` ruby
  zip :zip do |zip|
    # Currently broken in albacore need to submit fix.
    zip.flatten_zip = false
    zip.directories_to_zip ".bundle", "parameters", "build-scripts"
    zip.additional_files = ["configatron.env.yml", "Gemfile", "Gemfile.lock", "rakefile.rb"]
    zip.output_file = 'rake-package.zip'
    zip.output_path = File.dirname(__FILE__)
  end
```
