### PR TITLE
Added support for ILMerge target platform

### DIFF
--- a/lib/albacore/ilmerge.rb
+++ b/lib/albacore/ilmerge.rb
@@ -7,7 +7,7 @@ class IlMerge
   include Albacore::RunCommand
   include Configuration::ILMerge
 
-  attr_accessor :output, :resolver
+  attr_accessor :output, :resolver, :targetPlatform
   
   attr_array :parameters
 
@@ -24,6 +24,7 @@ class IlMerge
   def build_parameters
     params = Array.new @parameters
     params << %Q{/out:"#{output}"}
+    params << %Q{/targetPlatform:#{targetPlatform}} if @targetPlatform != nil
     raise ArgumentError, "you are required to call assemblies" if @assemblies == nil
     params += @assemblies
     params


### PR DESCRIPTION
Introduced a new optional parameter to ILMerge task to help workaround an issue with merging .NET v4 assemblies (http://stackoverflow.com/questions/2961357/using-ilmerge-with-net-4-libraries)
