### PR TITLE
Update assembly info builder to allow comments to be added to the top of...

### DIFF
--- a/lib/albacore/assemblyinfo.rb
+++ b/lib/albacore/assemblyinfo.rb
@@ -12,9 +12,9 @@ class AssemblyInfo
   attr_accessor :input_file, :output_file, :language,
    :version, :title, :description, :custom_attributes,
    :copyright, :com_visible, :com_guid, :company_name, :product_name,
-   :file_version, :trademark, :lang_engine, :informational_version
+   :file_version, :trademark, :lang_engine, :informational_version   
   
-  attr_array :namespaces, :custom_data
+  attr_array :namespaces, :custom_data, :initial_comments
   attr_hash :custom_attributes
   
   def initialize
@@ -90,7 +90,7 @@ class AssemblyInfo
         data = build_header
     end
 
-    data = build_using_statements(data) + data
+    data = build_initial_comments + build_using_statements(data) + data
 
     build_attribute(data, "AssemblyTitle", @title)
     build_attribute(data, "AssemblyDescription", @description)
@@ -167,6 +167,16 @@ class AssemblyInfo
     @custom_attributes.each do |key, value|
       build_attribute(data, key, value, true)
     end
+  end
+
+  def build_initial_comments
+    @initial_comments = [] if @initial_comments.nil?
+    comments = []
+    @initial_comments.each do |comment|
+        # Do language specific formatting here?
+        comments << comment
+    end
+    comments
   end
   
 end

--- a/spec/assemblyinfo_spec.rb
+++ b/spec/assemblyinfo_spec.rb
@@ -457,3 +457,21 @@ describe AssemblyInfo, "when an input file is provided with no attributes" do
     subject.scan(/[^\n]\n\z/).length.should == 1
   end
 end
+
+describe AssemblyInfo, "when specifying initial comments" do
+
+  include_context "asminfo task"
+
+  before :all do
+    @asm.initial_comments "// foo", "// bar"
+  end
+
+  subject{ @tester.build_and_read_assemblyinfo_file @asm }
+  
+  it "should write the initial comments at the top of the file" do
+    # Top of file is assumed to be before the first attribute. Comments are ignored.
+    s = subject.split($/)
+    s.index(%Q|// foo|).should == 0
+    s.index(%Q|// bar|).should == 1
+  end
+end

--- a/spec/support/AssemblyInfo/AssemblyInfo.test
+++ b/spec/support/AssemblyInfo/AssemblyInfo.test
@@ -1,9 +1,6 @@
+// foo
+// bar
 using System.Reflection;
 using System.Runtime.InteropServices;
-
-// A comment we want to see maintained
-[assembly: AssemblyCompany("Albacore")]
-[assembly: AssemblyVersion("0.2.2.0")]
-[assembly: CustomAttribute(12345)]
-
-// foo
+[assembly: AssemblyCompany("foo")]
+[assembly: AssemblyVersion("bar")]


### PR DESCRIPTION
... the file.

The reason for this is that we are using StyleCop and we want it to ignore the generated assembly info file.  We can do this by adding a <auto-generated/> comment to the file, but it must appear at the very top.
