### PR TITLE
Add splat to Application::puts parameter

### DIFF
--- a/lib/albacore/logging.rb
+++ b/lib/albacore/logging.rb
@@ -22,8 +22,8 @@ module Albacore
     def fatal *str, &block
       ::Albacore.application.logger.fatal *str, &block
     end
-    def puts str
-      ::Albacore.application.puts str
+    def puts *str
+      ::Albacore.application.puts *str
     end
     def err str
       ::Albacore.application.err str


### PR DESCRIPTION
Adding the splat keeps Albacore's puts method in sync with Ruby core's.

Before:

``` text
Z:\>bundle exec irb
irb(main):001:0> puts

=> nil
irb(main):002:0> puts :a, 42
a
42
=> nil
irb(main):003:0> require 'albacore'
=> true
irb(main):004:0> puts
ArgumentError: wrong number of arguments (0 for 1)
irb(main):005:0> puts :a, 42
ArgumentError: wrong number of arguments (2 for 1)
```

After:

``` text
Z:\>bundle exec irb
irb(main):001:0> puts

=> nil
irb(main):002:0> puts :a, 42
a
42
=> nil
irb(main):003:0> require 'albacore'
=> true
irb(main):004:0> puts

=> nil
irb(main):005:0> puts :a, 42
a
42
=> nil
```
