### PR TITLE
implementation of NuGet dependency groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 
 Gemfile.lock
+rspec/
 
 pkg/
 obj/

--- a/spec/nuspec_spec.rb
+++ b/spec/nuspec_spec.rb
@@ -124,4 +124,45 @@ describe Nuspec do
       @filedata.downcase.should include("<reference file='testFile2'/>".downcase)
     end
   end
+
+  describe 'when creating a package with dependendencies' do
+    let(:nuspec) do
+      nuspec = Nuspec.new
+      nuspec.id="nuspec_test"
+      nuspec.output_file = "nuspec_test.nuspec"
+      nuspec.version = "1.2.3"
+      nuspec.authors = "Author Name"
+      nuspec.description = "test_xml_document"
+      nuspec.copyright = "copyright 2011"
+      nuspec.working_directory = working_dir
+      nuspec.dependency "dependency1", "1.13"
+      nuspec.dependency "dependency2", "1.13-pre", "net45"
+      nuspec
+    end
+
+    before do
+      nuspec.execute
+      File.open(nuspec_output, "r") do |f|
+        @filedata = f.read
+      end
+    end
+
+    it "should produce the nuspec xml" do
+      File.exist?(nuspec_output).should be_true
+    end
+
+    it "should produce a valid xml file" do
+      is_valid = XmlValidator.validate(nuspec_output, schema_file)
+      is_valid.should be_true
+    end
+
+    it "should contain default group element" do
+      @filedata.downcase.should include("<group>".downcase)
+      @filedata.downcase.should include("</group>".downcase)
+    end
+
+    it "should contain default group element for .NET 4.5" do
+      @filedata.downcase.should include("<group targetFramework='net45'>".downcase)
+    end
+  end
 end

--- a/spec/support/nuspec/nuspec.xsd
+++ b/spec/support/nuspec/nuspec.xsd
@@ -6,6 +6,31 @@
     xmlns:mstns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
 >
+    <xs:complexType name="dependency">
+        <xs:attribute name="id" type="xs:string" use="required" />
+        <xs:attribute name="version" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="dependencyGroup">
+        <xs:sequence>
+            <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="dependency">
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="targetFramework" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="reference">
+        <xs:attribute name="file" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="referenceGroup">
+        <xs:sequence>
+            <xs:element name="reference" minOccurs="1" maxOccurs="unbounded" type="reference">
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="targetFramework" type="xs:string" use="optional" />
+    </xs:complexType>
+    
     <xs:element name="package">
         <xs:complexType>
             <xs:sequence>
@@ -21,6 +46,7 @@
                             <xs:element name="projectUrl" maxOccurs="1" minOccurs="0" type="xs:anyURI" />
                             <xs:element name="iconUrl" maxOccurs="1" minOccurs="0" type="xs:anyURI" />
                             <xs:element name="requireLicenseAcceptance" maxOccurs="1" minOccurs="0" type="xs:boolean" />
+                            <xs:element name="developmentDependency" maxOccurs="1" minOccurs="0" type="xs:boolean" />
                             <xs:element name="description" maxOccurs="1" minOccurs="1" type="xs:string" />
                             <xs:element name="summary" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="releaseNotes" maxOccurs="1" minOccurs="0" type="xs:string" />
@@ -30,12 +56,10 @@
                             <xs:element name="dependencies" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:attribute name="id" type="xs:string" use="required" />
-                                                <xs:attribute name="version" type="xs:string" use="optional" />
-                                            </xs:complexType>
-                                        </xs:element>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="dependency" type="dependency" />
+                                            <xs:element name="group" type="dependencyGroup" />
+                                        </xs:choice>
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
@@ -54,15 +78,15 @@
                             <xs:element name="references" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="reference" minOccurs="0" maxOccurs="unbounded">
-                                            <xs:complexType>
-                                                <xs:attribute name="file" type="xs:string" use="required" />
-                                            </xs:complexType>
-                                        </xs:element>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="reference" type="reference" />
+                                            <xs:element name="group" type="referenceGroup" />
+                                        </xs:choice>
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
                         </xs:all>
+                        <xs:attribute name="minClientVersion" use="optional" type="xs:string" />
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="files" minOccurs="0" maxOccurs="1" nillable="true">


### PR DESCRIPTION
updated the nuspec.xsd schema definition to the latest (NuGet 2.8)

added unit tests to validate the NuGet 2.0 NuSpec behavior

fixed - NuSpec 2.0 output now works as expected

resolves issue #85
