### PR TITLE
Find msbuild.exe in new location #126

### DIFF
--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -192,7 +192,7 @@ module Albacore
             key = "SOFTWARE\\Microsoft\\MSBuild\\#{msbuild_ver}"
             begin
               Win32::Registry::HKEY_LOCAL_MACHINE.open(key) do |reg|
-                  msb = reg['MSBuildOverrideTasksPath']
+                  msb = "#{reg['MSBuildOverrideTasksPath']}\msbuild.exe"
               end
             rescue
               trace "failed to open HKLM\\#{key}"

--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -186,24 +186,23 @@ module Albacore
         if ::Rake::Win32.windows?
           require 'win32/registry'
           trace 'build tasktype finding msbuild.exe'
- 
           %w{12.0 4.0 3.5 2.0}.collect { |msbuild_ver|
-            msb = :something_nonexistent
-            key = "SOFTWARE\\Microsoft\\MSBuild\\#{msbuild_ver}"
+            msb = "msbuild_not_found"
+            key = "SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions\\#{msbuild_ver}"
             begin
               Win32::Registry::HKEY_LOCAL_MACHINE.open(key) do |reg|
-                  msb = "#{reg['MSBuildOverrideTasksPath']}\msbuild.exe"
+                  msb = "#{reg['MSBuildToolsPath']}\\msbuild.exe"
               end
             rescue
-              trace "failed to open HKLM\\#{key}"
+              error "failed to open HKLM\\#{key}\\MSBuildToolsPath"
             end
- 
             CrossPlatformCmd.which(msb) ? msb : nil
           }.compact.first
         else
           nil
         end
       end
+
     end
     class Task
       def initialize command_line

--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -187,10 +187,9 @@ module Albacore
           require 'win32/registry'
           trace 'build tasktype finding msbuild.exe'
  
-          #Get msbuild path from registry
-          %w{12.0 4.0 3.5 2.0}.collect { |msbuid_ver|
+          %w{12.0 4.0 3.5 2.0}.collect { |msbuild_ver|
             msb = :something_nonexistent
-            key = "SOFTWARE\\Microsoft\\MSBuild\\#{msbuid_ver}"
+            key = "SOFTWARE\\Microsoft\\MSBuild\\#{msbuild_ver}"
             begin
               Win32::Registry::HKEY_LOCAL_MACHINE.open(key) do |reg|
                   msb = reg['MSBuildOverrideTasksPath']


### PR DESCRIPTION
Pullrequest fixes  #126. Trying to read the msbuild.exe locations from registry instead of folder based look-up to have a consistent look-up strategy.