### PR TITLE
Fixed FPM test on windows, to check correct path with drive letter

### DIFF
--- a/spec/fpm_app_spec_spec.rb
+++ b/spec/fpm_app_spec_spec.rb
@@ -89,8 +89,14 @@ describe ::Albacore::FpmAppSpec, 'when generating command from valid AppSpec' do
     expect(flags['--license']).to eq 'MIT'
   end
 
-  it 'should generate command "look in this directory" flag' do
-    expect(flags['-C']).to eq '/a/b'
+  if ::Rake::Win32.windows?
+    it 'should generate command "look in this directory" flag' do
+      expect(flags['-C']).should match  /^.:\/a\/b$/
+    end
+  else
+    it 'should generate command "look in this directory" flag' do
+      expect(flags['-C']).to eq '/a/b'
+    end
   end
 
   it 'should generate command depends' do


### PR DESCRIPTION
Hey. I would like to help a bit with albacore, so I have started to look around source code. Unfortunately one of FPM tests was failing on windows, due to path containing drive letter.
