### PR TITLE
Fixed CrossPlatformCmd.which for (absolute) paths with spaces.

### DIFF
--- a/lib/albacore/cross_platform_cmd.rb
+++ b/lib/albacore/cross_platform_cmd.rb
@@ -191,8 +191,11 @@ module Albacore
 
       cmd = ::Rake::Win32.windows? ? 'where' : 'which'
       parameters = []
-      parameters << Paths.normalise_slashes(file) if dir == '.'
-      parameters << Paths.normalise_slashes("#{dir}:#{file}") unless dir == '.'
+      pattern = if dir == '.' then file
+      elsif ::Rake::Win32.windows? then "#{dir}:#{file}"
+      else executable
+      end
+      parameters << Paths.normalise_slashes("\"#{pattern}\"")
       parameters << '2> nul' if ::Rake::Win32.windows?
       cmd, parameters = Paths.normalise cmd, parameters
       cmd = "#{cmd} #{parameters.join(' ')}"

--- a/spec/cross_platform_cmd_spec.rb
+++ b/spec/cross_platform_cmd_spec.rb
@@ -10,6 +10,10 @@ describe Albacore::CrossPlatformCmd.method(:which), "what happens when calling #
   it "should return a non-null path" do
     expect(subject.call("ruby")).to_not be_empty
   end
+  it "should return its input if given an absolute path to an executable that exists" do
+    pathToRuby = subject.call("ruby")
+    expect(subject.call(pathToRuby)).to eq(pathToRuby)
+  end
   it "should return nil if nothing was found" do
     expect(subject.call("notlikelyonsystem")).to be_nil
   end


### PR DESCRIPTION
Added quotation for input argument to which/where, in order to handle paths with spaces (e.g. "C:\Program Files (x86)\MSBuild\12.0\Bin\MSBuild.exe").

Differentiated input argument to which/where for absolute paths -- the "path:file" arg. format for where on Windows is not supported by which on Unix (neither on OS X, nor on Ubuntu Linux).