### PR TITLE
Registry entries might not be ordered.

### DIFF
--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -189,7 +189,6 @@ module Albacore
     	  trace 'build tasktype finding msbuild.exe'
 
     	  msb = "msbuild_not_found"
-    	  maxVersion = -1
         versions = Albacore.find_msbuild_versions
         if versions.any?
           msb = versions.max[1]

--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -191,7 +191,7 @@ module Albacore
     	  msb = "msbuild_not_found"
         versions = Albacore.find_msbuild_versions
         if versions.any?
-          msb = versions.max[1]
+          msb = versions[versions.keys.max]
         end
     	  CrossPlatformCmd.which(msb) ? msb : nil
       end

--- a/lib/albacore/task_types/build.rb
+++ b/lib/albacore/task_types/build.rb
@@ -6,6 +6,7 @@ require 'albacore/cmd_config'
 require 'albacore/cross_platform_cmd'
 require 'albacore/logging'
 require 'albacore/facts'
+require 'albacore/task_types/find_msbuild_versions'
 
 module Albacore
   module Build
@@ -189,25 +190,10 @@ module Albacore
 
     	  msb = "msbuild_not_found"
     	  maxVersion = -1
-    	  begin
-    		Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\MSBuild\ToolsVersions') do |toolsVersion|
-    		  toolsVersion.each_key do |key|
-    			begin
-    			  versionKey = toolsVersion.open(key)
-    			  version = key.to_i
-    			  if maxVersion < version
-    				maxVersion = version
-    				msb = "#{versionKey['MSBuildToolsPath']}\\msbuild.exe"
-    			  end
-    			rescue
-    			  error "failed to open #{key}"
-    			end
-    		  end
-    		end
-    	  rescue
-    		error "failed to open HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions"
-    	  end
-
+        versions = Albacore.find_msbuild_versions
+        if versions.any?
+          msb = versions.max[1]
+        end
     	  CrossPlatformCmd.which(msb) ? msb : nil
       end
 

--- a/lib/albacore/task_types/find_msbuild_versions.rb
+++ b/lib/albacore/task_types/find_msbuild_versions.rb
@@ -1,0 +1,25 @@
+require 'rake'
+module Albacore
+  def self.find_msbuild_versions
+    return nil unless ::Rake::Win32.windows?
+    require 'win32/registry'
+    retval = Hash.new
+    begin
+      Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Microsoft\MSBuild\ToolsVersions') do |toolsVersion|
+        toolsVersion.each_key do |key|
+          begin
+            versionKey = toolsVersion.open(key)
+            version = key.to_i
+            msb = File.join(versionKey['MSBuildToolsPath'],'msbuild.exe')
+            retval[version] = msb
+          rescue
+            error "failed to open #{key}"
+          end
+        end
+      end
+    rescue
+      error "failed to open HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions"
+    end
+    return retval
+  end
+end


### PR DESCRIPTION
If the registry entries are in another order than expected when iterating over the entries, the wrong version of msbuild is used. Instead of assuming that the entries are ordered, we can use ruby "max".