### PR TITLE
Passing rake task parameters down to tasks created with Albacore.

### DIFF
--- a/lib/albacore/dsl.rb
+++ b/lib/albacore/dsl.rb
@@ -12,18 +12,18 @@ module Albacore
     # a rake task type for outputting assembly versions
     def asmver *args, &block
       require 'albacore/task_types/asmver'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::Asmver::Config.new
-        yield c
+        yield c, args
         Albacore::Asmver::Task.new(c.opts).execute
       end
     end
 
     def asmver_files *args, &block
       require 'albacore/task_types/asmver'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::Asmver::MultipleFilesConfig.new
-        yield c
+        yield c, args
 
         c.configurations.each do |conf|
           trace { "generating asmver for #{conf}" }
@@ -36,9 +36,9 @@ module Albacore
     # with MsBuild
     def build *args, &block
       require 'albacore/task_types/build'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::Build::Config.new
-        yield c
+        yield c, args
 
         fail "unable to find MsBuild or XBuild" unless c.exe
         command = Albacore::Build::Cmd.new(c.work_dir, c.exe, c.parameters)
@@ -49,11 +49,11 @@ module Albacore
     # restore the nugets to the solution
     def nugets_restore *args, &block
       require 'albacore/task_types/nugets_restore'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::NugetsRestore::Config.new
-        yield c
+        yield c, args
 
-        c.ensure_authentication! 
+        c.ensure_authentication!
 
         c.packages.each do |p|
           command = Albacore::NugetsRestore::Cmd.new(c.work_dir, c.exe, c.opts_for_pkgcfg(p))
@@ -65,9 +65,9 @@ module Albacore
     # pack nugets
     def nugets_pack *args, &block
       require 'albacore/task_types/nugets_pack'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::NugetsPack::Config.new
-        yield c
+        yield c, args
         Albacore::NugetsPack::ProjectTask.new(c.opts).execute
       end
     end
@@ -76,9 +76,9 @@ module Albacore
     # tests with albacore
     def test_runner *args, &block
       require 'albacore/task_types/test_runner'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::TestRunner::Config.new
-        yield c
+        yield c, args
         Albacore::TestRunner::Task.new(c.opts).execute
       end
     end
@@ -86,9 +86,9 @@ module Albacore
     # Restore hint paths to registered nugets
     def restore_hint_paths *args, &block
       require 'albacore/tools/restore_hint_paths'
-      Albacore.define_task *args do
+      Albacore.define_task *args do |task_name, args|
         c = Albacore::RestoreHintPaths::Config.new
-        yield c
+        yield c, args
 
         t = Albacore::RestoreHintPaths::Task.new c
         t.execute
@@ -99,16 +99,16 @@ module Albacore
     def appspecs *args, &block
       if Albacore.windows?
         require 'albacore/cpack_app_spec'
-        Albacore.define_task *args do
+        Albacore.define_task *args do |task_name, args|
           c = ::Albacore::CpackAppSpec::Config.new
-          yield c
+          yield c, args
           ::Albacore::CpackAppSpec::Task.new(c.opts).execute
         end
       else
         require 'albacore/fpm_app_spec'
-        Albacore.define_task *args do
+        Albacore.define_task *args do |task_name, args|
           c = ::Albacore::FpmAppSpec::Config.new
-          yield c
+          yield c, args
           ::Albacore::FpmAppSpec::Task.new(c.opts).execute
         end
       end


### PR DESCRIPTION
When calling a rake task created with Albacore, the parameters passed to the rake task are now available to the Albacore task.

e.g.

```
test_runner :unit_tests, :path do |nunit, args|
#args.path is mypath
end
```
```
rake unit_tests[mypath]
```
