### PR TITLE
Pre-install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 
 language: ruby
 
+before_install:
+  - gem install bundler
+
 install:
   - travis_retry sudo bash -c "echo deb http://badgerports.org lucid main >> /etc/apt/sources.list"
   - travis_retry sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E1FAD0C


### PR DESCRIPTION
#### Summary
Update bundler via `before_install`.

#### Details
When forked and built on Travis-CI's new architecture, the [builds fail](https://travis-ci.org/jaredreynolds/albacore/builds/113811808) because bundler is too old (1.7.6).  Installing bundler in `before_install` currently provides version 1.11.2 which allows the [build to pass](https://travis-ci.org/jaredreynolds/albacore/builds/114716413) on the new architecture.
