### PR TITLE
Support batching tests

### DIFF
--- a/lib/albacore/task_types/test_runner.rb
+++ b/lib/albacore/task_types/test_runner.rb
@@ -26,6 +26,7 @@ module Albacore
         @copy_local = false
         @is_ms_test = false
         @clr_command = true
+        @execute_as_batch = false
         @files = []
       end
 
@@ -38,7 +39,8 @@ module Albacore
           :is_ms_test  => @is_ms_test, 
           :exe         => @exe,
           :parameters  => @parameters,
-          :clr_command => @clr_command)
+          :clr_command => @clr_command,
+          :execute_as_batch => @execute_as_batch)
       end
 
       attr_path_accessor :settings do |s|
@@ -63,6 +65,11 @@ module Albacore
         @is_ms_test = true
       end 
 
+      # Will cause the executable to be run only once, testing all files as a batch.
+      def execute_as_batch
+        @execute_as_batch = true
+      end
+
       private
       def files
         if @files.respond_to? :each
@@ -78,9 +85,9 @@ module Albacore
 
       # expects both parameters and executable to be relative to the
       # work_dir parameter
-      def initialize work_dir, executable, parameters, file, clr_command = true
+      def initialize work_dir, executable, parameters, files, clr_command = true
         @work_dir, @executable = work_dir, executable
-        @parameters = parameters.to_a.unshift(file)
+        @parameters = files.concat(parameters.to_a)
         @clr_command = clr_command
       end
 
@@ -103,10 +110,18 @@ module Albacore
       def execute
         raise ArgumentError, 'missing :exe' unless @opts.get :exe
         raise ArgumentError, 'missing :files' unless @opts.get :files
-        commands = []
+        raise ArgumentError, 'cannot specify both execute_as_batch and is_ms_test' if @opts.get :execute_as_batch and @opts.get :is_ms_test
+        raise ArgumentError, 'cannot specify both execute_as_batch and is_ms_test' if @opts.get :execute_as_batch and @opts.get :copy_local
+
         @opts.get(:files).each do |dll|
           raise ArgumentError, "could not find test dll '#{dll}' in dir #{FileUtils.pwd}" unless File.exists? dll
-          commands.push build_command_for dll
+        end
+
+        commands = []
+        if @opts.get(:execute_as_batch)
+          commands = build_command_for_all_dlls
+        else
+          commands = @opts.get(:files).map { |dll| build_command_for dll }
         end
 
         execute_commands commands
@@ -127,10 +142,20 @@ module Albacore
           Albacore::TestRunner::Cmd.new dir,
                                         exe,
                                         @opts.get(:parameters, []),
-                                        filename,
+                                        [filename],
                                         @opts.get(:clr_command)
         end
       end
+
+      def build_command_for_all_dlls
+        command = Albacore::TestRunner::Cmd.new '.',
+                                                @opts.get(:exe),
+                                                @opts.get(:parameters, []),
+                                                @opts.get(:files),
+                                                @opts.get(:clr_command)
+        [command]
+      end
+
       def handle_directory dll, exe, &block
         if @opts.get(:copy_local)
           # TODO: #mktmpdir is not always reliable; consider contributing a patch to ruby?

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -149,4 +149,19 @@ describe ::Albacore::TestRunner::Task do
       expect(subject.commands[0].invocations[0].parameters).to include 'Rakefile'
     end
   end
+
+  context 'is_ms_test specified' do
+    let :config do
+      config = ::Albacore::TestRunner::Config.new
+      config.exe = 'test-runner.exe'
+      config.is_ms_test
+      config.files = 'utils_spec.rb' # not a real DLL, but we need something that exists
+      config
+    end
+
+    it 'should handle is_ms_test by adding testcontainer to the filename' do
+      expect(subject.commands.length).to eq(1)
+      expect(subject.commands[0].invocations[0].parameters.last).to eq('/testcontainer:utils_spec.rb')
+    end
+  end
 end

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -9,22 +9,6 @@ describe ::Albacore::TestRunner::Config do
   it do
     should respond_to :copy_local
   end
-  it do
-    should respond_to :native_exe
-  end
-end
-describe ::Albacore::TestRunner::Config do
-  subject do
-    ::Albacore::TestRunner::Config.new
-  end
-
-  before :each do
-    subject.native_exe
-  end
-
-  it 'should have clr_command=false' do
-    expect(subject.opts.get(:clr_command)).to be false
-  end
 end
 
 describe ::Albacore::TestRunner::Task do
@@ -55,6 +39,45 @@ describe ::Albacore::TestRunner::Task do
 
   subject do
     create_task_that_intercepts_commands config.opts
+  end
+
+  context "native_exe not specified" do
+    let :config do
+      config = ::Albacore::TestRunner::Config.new
+      config.exe = 'test-runner.exe'
+      config.files = 'utils_spec.rb' # not a real DLL, but we need something that exists
+      config
+    end
+
+    it "should execute command as CLR command" do
+      subject.execute
+      expect(subject.commands[0].invocations[0].options[:clr_command]).to eq(true)
+    end
+
+    it "should include the file at the beginning of the command" do
+      subject.execute
+      expect(subject.commands[0].invocations[0].parameters.first).to eq('utils_spec.rb')
+    end
+  end
+
+  context "native_exe specified" do
+    let :config do
+      config = ::Albacore::TestRunner::Config.new
+      config.exe = 'test-runner.exe'
+      config.files = 'utils_spec.rb' # not a real DLL, but we need something that exists
+      config.native_exe
+      config
+    end
+
+    it "should execute command as non-CLR command" do
+      subject.execute
+      expect(subject.commands[0].invocations[0].options[:clr_command]).to eq(false)
+    end
+
+    it "should include the file at the beginning of the command" do
+      subject.execute
+      expect(subject.commands[0].invocations[0].parameters.first).to eq('utils_spec.rb')
+    end
   end
 
   context "extra parameters and options specified" do

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -4,16 +4,10 @@ require 'map'
 
 describe ::Albacore::TestRunner::Config do
   it do
-    should respond_to :files=
-  end
-  it do
     should_not respond_to :files
   end
   it do
     should respond_to :copy_local
-  end
-  it do
-    should respond_to :exe=
   end
   it do
     should respond_to :native_exe

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -80,24 +80,6 @@ describe ::Albacore::TestRunner::Cmd do
 end
 
 describe ::Albacore::TestRunner::Task do
-  let :config do
-    config = ::Albacore::TestRunner::Config.new
-    config.files = 'a/b/c/file.dll'
-    config.exe   = 'test-runner.exe'
-    config.add_parameter '/TestResults=abc.xml'
-    config
-  end
-
-  subject do
-    ::Albacore::TestRunner::Task.new(config.opts)
-  end
-
-  it do
-    should respond_to :execute
-  end
-end
-
-describe ::Albacore::TestRunner::Task do
   def create_task_that_intercepts_commands opts
     task = ::Albacore::TestRunner::Task.new(config.opts)
     def task.execute_commands commands

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -26,6 +26,7 @@ describe ::Albacore::TestRunner::Task do
       @commands
     end
 
+    task.execute
     task
   end
 
@@ -50,12 +51,10 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should execute command as CLR command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].options[:clr_command]).to eq(true)
     end
 
     it "should include the file at the beginning of the command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters.first).to eq('utils_spec.rb')
     end
   end
@@ -70,12 +69,10 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should execute command as non-CLR command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].options[:clr_command]).to eq(false)
     end
 
     it "should include the file at the beginning of the command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters.first).to eq('utils_spec.rb')
     end
   end
@@ -91,12 +88,10 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should include the parameters at the end of the command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters.last(2)).to eq(['/magic_parameter1', '/magic_parameter2'])
     end
 
     it "should include the file at the beginning of the command" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters.first).to eq('utils_spec.rb')
     end
   end
@@ -110,13 +105,11 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should run the command from the current directory" do
-      subject.execute
       expect(subject.commands[0].invocations[0].options[:work_dir]).to eq('.')
       expect(subject.commands[0].invocations[0].executable).to eq('test-runner.exe')
     end
 
     it "should reference the file without directory qualifiers" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters).to include 'utils_spec.rb'
     end
   end
@@ -130,13 +123,11 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should run the command from the subdirectory" do
-      subject.execute
       expect(subject.commands[0].invocations[0].options[:work_dir]).to eq('tools')
       expect(subject.commands[0].invocations[0].executable).to eq('../test-runner.exe')
     end
 
     it "should reference the file without directory qualifiers" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters).to include 'fluent_migrator_spec.rb'
     end
   end
@@ -150,13 +141,11 @@ describe ::Albacore::TestRunner::Task do
     end
 
     it "should run the command from the parent directory" do
-      subject.execute
       expect(subject.commands[0].invocations[0].options[:work_dir]).to eq('..')
       expect(subject.commands[0].invocations[0].executable).to eq('../spec/test-runner.exe')
     end
 
     it "should reference the file without directory qualifiers" do
-      subject.execute
       expect(subject.commands[0].invocations[0].parameters).to include 'Rakefile'
     end
   end

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -228,4 +228,27 @@ describe ::Albacore::TestRunner::Task do
       expect(subject.commands[0].invocations[0].parameters).to eq(['utils_spec.rb', 'tools/fluent_migrator_spec.rb'])
     end
   end
+
+  context 'multiple files in subdirectory tested as a batch' do
+    let :config do
+      config = ::Albacore::TestRunner::Config.new
+      config.exe = 'test-runner.exe'
+      config.files = ['testdata/Gemfile', 'testdata/Rakefile'] # not real DLLs, but we need files that exist
+      config.execute_as_batch
+      config
+    end
+
+    it 'should execute a single command' do
+      expect(subject.commands.length).to eq(1)
+    end
+
+    it "should run the command from the subdirectory" do
+      expect(subject.commands[0].invocations[0].options[:work_dir]).to eq('testdata')
+      expect(subject.commands[0].invocations[0].executable).to eq('../test-runner.exe')
+    end
+
+    it 'should reference the files without directory qualitifers' do
+      expect(subject.commands[0].invocations[0].parameters).to eq(['Gemfile', 'Rakefile'])
+    end
+  end
 end

--- a/spec/test_runner_spec.rb
+++ b/spec/test_runner_spec.rb
@@ -164,4 +164,19 @@ describe ::Albacore::TestRunner::Task do
       expect(subject.commands[0].invocations[0].parameters.last).to eq('/testcontainer:utils_spec.rb')
     end
   end
+
+  context 'multiple files' do
+    let :config do
+      config = ::Albacore::TestRunner::Config.new
+      config.exe = 'test-runner.exe'
+      config.files = ['utils_spec.rb', 'tools/fluent_migrator_spec.rb'] # not real DLLs, but we need files that exist
+      config
+    end
+
+    it 'should execute one command per file' do
+      expect(subject.commands.length).to eq(2)
+      expect(subject.commands[0].invocations[0].parameters.last).to eq('utils_spec.rb')
+      expect(subject.commands[1].invocations[0].parameters.last).to eq('fluent_migrator_spec.rb')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #207.

@haf,  I have to ask forgiveness. I have broken the cardinal rule of Pull Requests by substantially changing the base code, and its style. I fear it will not be to your taste, and apologize. But if you have patience to work with me, I'm happy to fix anything you don't like.

An explanation:

In order to test the test-batching, I found that I would need access to the `TestRunner::Cmd`  objects that the `TestRunner::Task` was making. Relying on creating a Cmd in the specs and investigating its behaviour would no longer work. So I made a change to the Task to support this. At the same time, it became clear that poking `execute_tests_for dll` wouldn't work either.
So I, in stages, replaced most of the specs so they would be driven from the `Task` level, and cover (nearly) all behaviour in the `Task` and `Cmd`s. It's counter to the existing approach, but is more refactoring-friendly, and is an approach that I've seen work very well in other projects. By driving the code in a way that more closely matches how the users would, you can worry a little less about the internal details.

So:

1. I introduced a private `execute_commands` method on the Task, which is overridden in the specs. The original behaviour is so simple that not exercising it during the specs is hopefully forgivable. I'm not usually a fan of overriding production methods in tests, but it seems no worse than sending a signal to a private method.
2. I updated existing specs to provide close to end-to-end coverage, from the config object down to the command, to mirror how the new specs would be written.
3. I added minor extra specs, e.g. for `is_ms_test`. I did not add an end-to-end spec for `copy_local`, as I wasn't sure you'd want to add all that extra copying around during test runs
4. The new specs change their working directory to better work with existing "test" files. The task requires test files to actually exist, so I co-opted existing files in the hierarchy. By running in the `specs` directory, it's possible to test a negative relative path exactly. I know, perhaps this was an odd choice.
5. Finally introduced specs for the `execute_as_batch` option, and implemented the feature. There's no "path shortening" feature for this yet - the tests would execute in the current directory. If you'd like, I can see about looking for the lowest common directory above the "test files" and execute from there, or some such. Or this could be introduced later, if you think it worthwhile.

So, yeah. Perhaps not what you were expecting. And maybe totally against the style you'd like to have for the tests. And my lack of ruby/rspec knowledge probably means I've made a terrible mess of all of it. Sorry. But again, if you're willing, I'll work to mold things into a shape you prefer.

Thanks for considering the PR.