### PR TITLE
#229 Add detection of MSBuild 15

### DIFF
--- a/lib/albacore/task_types/find_msbuild_versions.rb
+++ b/lib/albacore/task_types/find_msbuild_versions.rb
@@ -20,6 +20,11 @@ module Albacore
     rescue
       error "failed to open HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions"
     end
+	
+	# MSBuild 15, assume default installation path
+	vs2017_dir = Dir[File.join(ENV['ProgramFiles(x86)'].gsub('\\', '/'), 'Microsoft Visual Studio', '2017', '*')].first
+	retval[15] = File.join(vs2017_dir, 'MSBuild', '15.0', 'Bin') unless vs2017_dir.nil?
+	
     return retval
   end
 end

--- a/lib/albacore/task_types/find_msbuild_versions.rb
+++ b/lib/albacore/task_types/find_msbuild_versions.rb
@@ -20,11 +20,11 @@ module Albacore
     rescue
       error "failed to open HKLM\\SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions"
     end
-	
-	# MSBuild 15, assume default installation path
-	vs2017_dir = Dir[File.join(ENV['ProgramFiles(x86)'].gsub('\\', '/'), 'Microsoft Visual Studio', '2017', '*')].first
-	retval[15] = File.join(vs2017_dir, 'MSBuild', '15.0', 'Bin') unless vs2017_dir.nil?
-	
+    
+    # MSBuild 15, assume default installation path
+    vs2017_dir = Dir[File.join(ENV['ProgramFiles(x86)'].gsub('\\', '/'), 'Microsoft Visual Studio', '2017', '*')].first
+    retval[15] = File.join(vs2017_dir, 'MSBuild', '15.0', 'Bin') unless vs2017_dir.nil?
+    
     return retval
   end
 end


### PR DESCRIPTION
MSBuild 15 is now bundled with VS2017. It doesn't use the same path or
registry keys as previous versions did.