### PR TITLE
Use rake 12 (due to CVE-2020-8130)

### DIFF
--- a/albacore.gemspec
+++ b/albacore.gemspec
@@ -21,7 +21,7 @@ EOF
 
   s.rubyforge_project = 'albacore'
 
-  s.add_dependency 'rake', '~> 10' # this gem builds on rake
+  s.add_dependency 'rake', '~> 12' # this gem builds on rake
   s.add_dependency 'map', '~> 6.5' # https://github.com/ahoward/map for options handling
   s.add_dependency 'nokogiri', '~> 1.5' # used to manipulate and read *proj files
   s.add_dependency 'semver2', '~> 3.4'


### PR DESCRIPTION
See https://github.com/advisories/GHSA-jppv-gw3r-w3q8 about the vulnerability in Rake.

The tests passes on Travis with this change: https://travis-ci.org/dentarg/albacore/builds/659144935#L1259